### PR TITLE
Add GPT panel example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Then run the following to build the plugin:
     npm install
     npm run dev
 
+If Grafana logs warn about a missing `module.js`, make sure the plugin has been
+built with `npm run dev` (or `npm run build`).
+
 Finally, use docker compose to run a Grafana instance with access to the plugin:
 
     docker compose up

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Grafana container in docker-compose is provisioned with the `grafana-llm-app
 This plugin makes use of the `@grafana/experimental` package to make requests to OpenAI via the `grafana-llm-app` plugin, which provides an authenticating proxy and handles streaming responses using Grafana Live.
 
 Take a look at `src/pages/ExamplePage.tsx` to see how to make requests and use responses. You can also take a look at `extensions/panelExplainer.tsx` to see how to add a [plugin extension] utilizing the same APIs.
+You can also add the new `GPT Query Panel` from `src/gpt-panel` to ask questions directly from a dashboard.
 
 You can also toggle the value of `disabled` for the `grafana-llm-app` plugin in `provisioning/plugins/apps.yaml` to see what happens when the LLM plugin is unavailable.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Grafana container in docker-compose is provisioned with the `grafana-llm-app
 This plugin makes use of the `@grafana/experimental` package to make requests to OpenAI via the `grafana-llm-app` plugin, which provides an authenticating proxy and handles streaming responses using Grafana Live.
 
 Take a look at `src/pages/ExamplePage.tsx` to see how to make requests and use responses. You can also take a look at `extensions/panelExplainer.tsx` to see how to add a [plugin extension] utilizing the same APIs.
-You can also add the new `GPT Query Panel` from `src/gpt-panel` to ask questions directly from a dashboard. The panel includes a brief summary of recent data for context when sending the prompt to the LLM.
+You can also add the new `GPT Query Panel` from `src/gpt-panel` to ask questions directly from a dashboard. When sending the prompt to the LLM, the panel summarizes the latest values from any data it receives so the answer can include recent dashboard context.
 
 You can also toggle the value of `disabled` for the `grafana-llm-app` plugin in `provisioning/plugins/apps.yaml` to see what happens when the LLM plugin is unavailable.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Grafana container in docker-compose is provisioned with the `grafana-llm-app
 This plugin makes use of the `@grafana/experimental` package to make requests to OpenAI via the `grafana-llm-app` plugin, which provides an authenticating proxy and handles streaming responses using Grafana Live.
 
 Take a look at `src/pages/ExamplePage.tsx` to see how to make requests and use responses. You can also take a look at `extensions/panelExplainer.tsx` to see how to add a [plugin extension] utilizing the same APIs.
-You can also add the new `GPT Query Panel` from `src/gpt-panel` to ask questions directly from a dashboard.
+You can also add the new `GPT Query Panel` from `src/gpt-panel` to ask questions directly from a dashboard. The panel includes a brief summary of recent data for context when sending the prompt to the LLM.
 
 You can also toggle the value of `disabled` for the `grafana-llm-app` plugin in `provisioning/plugins/apps.yaml` to see what happens when the LLM plugin is unavailable.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Then run the following to build the plugin:
     npm install
     npm run dev
 
+To start the backend portion of the plugin, compile the Go code into the `dist`
+folder:
+
+    GOOS=linux GOARCH=amd64 go build -o dist/gpx_llmexamples_linux_amd64 ./pkg
+
 If Grafana logs warn about a missing `module.js`, make sure the plugin has been
 built with `npm run dev` (or `npm run build`).
 

--- a/src/gpt-panel/module.js
+++ b/src/gpt-panel/module.js
@@ -1,0 +1,4 @@
+import { PanelPlugin } from '@grafana/data';
+import { GptPanel } from './panel';
+
+export const plugin = new PanelPlugin(GptPanel);

--- a/src/gpt-panel/module.ts
+++ b/src/gpt-panel/module.ts
@@ -1,0 +1,4 @@
+import { PanelPlugin } from '@grafana/data';
+import { GptPanel } from './panel';
+
+export const plugin = new PanelPlugin(GptPanel);

--- a/src/gpt-panel/panel.js
+++ b/src/gpt-panel/panel.js
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { FieldType } from '@grafana/data';
+import { llms } from '@grafana/experimental';
+import { Button, Input, Spinner } from '@grafana/ui';
+import { useAsync } from 'react-use';
+
+export function GptPanel({ data }) {
+  const [input, setInput] = useState('');
+  const [message, setMessage] = useState('');
+  const [reply, setReply] = useState('');
+
+  const { loading, error, value } = useAsync(async () => {
+    const openAIHealthDetails = await llms.openai.enabled();
+    const enabled = openAIHealthDetails.ok;
+    if (!enabled || message === '') {
+      return { enabled };
+    }
+
+    const now = Date.now();
+    const context = JSON.stringify(
+      (data.series || []).map((series) => {
+        const timeField = series.fields.find((f) => f.type === FieldType.time);
+        const valueField = series.fields.find((f) => f.type !== FieldType.time);
+        const recent = [];
+        if (timeField && valueField) {
+          for (let i = timeField.values.length - 1; i >= 0; i--) {
+            const ts = timeField.values.get(i);
+            if (now - ts <= 5 * 60 * 1000) {
+              recent.unshift(valueField.values.get(i));
+            } else {
+              break;
+            }
+          }
+        }
+        return {
+          name: series.name ?? (valueField && valueField.name),
+          lastValues: recent.slice(-5),
+        };
+      })
+    );
+
+    const response = await llms.openai.chatCompletions({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: `${message}\nDashboard context: ${context}` },
+      ],
+    });
+    setReply(response.choices[0].message.content);
+    return { enabled };
+  }, [message, data]);
+
+  return (
+    <div style={{ padding: '8px' }}>
+      {value?.enabled ? (
+        <>
+          <Input
+            value={input}
+            onChange={(e) => setInput(e.currentTarget.value)}
+            placeholder="Ask GPT"
+          />
+          <Button onClick={() => setMessage(input)} style={{ marginLeft: '4px' }}>
+            Send
+          </Button>
+          <div style={{ marginTop: '8px' }}>{loading ? <Spinner /> : reply}</div>
+          {error && <div>Error: {error.message}</div>}
+        </>
+      ) : (
+        <div>LLM plugin not enabled.</div>
+      )}
+    </div>
+  );
+}

--- a/src/gpt-panel/panel.tsx
+++ b/src/gpt-panel/panel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { PanelProps } from '@grafana/data';
+import { PanelProps, FieldType } from '@grafana/data';
 import { llms } from '@grafana/experimental';
 import { Button, Input, Spinner } from '@grafana/ui';
 import { useAsync } from 'react-use';
@@ -21,12 +21,25 @@ export function GptPanel({ data }: Props) {
       return { enabled };
     }
 
+    const now = Date.now();
     const context = JSON.stringify(
       data.series?.map((series) => {
-        const values = series.fields[0].values.toArray();
+        const timeField = series.fields.find((f) => f.type === FieldType.time);
+        const valueField = series.fields.find((f) => f.type !== FieldType.time);
+        const recent: any[] = [];
+        if (timeField && valueField) {
+          for (let i = timeField.values.length - 1; i >= 0; i--) {
+            const ts = timeField.values.get(i) as number;
+            if (now - ts <= 5 * 60 * 1000) {
+              recent.unshift(valueField.values.get(i));
+            } else {
+              break;
+            }
+          }
+        }
         return {
-          name: series.name ?? series.fields[0].name,
-          lastValues: values.slice(-5),
+          name: series.name ?? valueField?.name,
+          lastValues: recent.slice(-5),
         };
       }) ?? []
     );

--- a/src/gpt-panel/panel.tsx
+++ b/src/gpt-panel/panel.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { PanelProps } from '@grafana/data';
+import { llms } from '@grafana/experimental';
+import { Button, Input, Spinner } from '@grafana/ui';
+import { useAsync } from 'react-use';
+import { getDashboardSrv, getBackendSrv } from '@grafana/runtime';
+
+interface Props extends PanelProps<{}> {}
+
+export function GptPanel({ data }: Props) {
+  const [input, setInput] = useState('');
+  const [message, setMessage] = useState('');
+  const [reply, setReply] = useState('');
+
+  const { loading, error, value } = useAsync(async () => {
+    const openAIHealthDetails = await llms.openai.enabled();
+    const enabled = openAIHealthDetails.ok;
+    if (!enabled) {
+      return { enabled };
+    }
+    if (message === '') {
+      return { enabled };
+    }
+
+    let context = '';
+    try {
+      const dashboard = getDashboardSrv().getCurrent();
+      const dashJson = await getBackendSrv().get(`/api/dashboards/uid/${dashboard?.uid}`);
+      context = JSON.stringify(dashJson.dashboard.panels?.slice(0, 3));
+    } catch (err) {
+      console.error('failed getting dashboard context', err);
+    }
+
+    const response = await llms.openai.chatCompletions({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: `${message}\nDashboard context: ${context}` },
+      ],
+    });
+    setReply(response.choices[0].message.content);
+    return { enabled };
+  }, [message]);
+
+  return (
+    <div style={{ padding: '8px' }}>
+      {value?.enabled ? (
+        <>
+          <Input value={input} onChange={(e) => setInput(e.currentTarget.value)} placeholder="Ask GPT" />
+          <Button onClick={() => setMessage(input)} style={{ marginLeft: '4px' }}>
+            Send
+          </Button>
+          <div style={{ marginTop: '8px' }}>{loading ? <Spinner /> : reply}</div>
+          {error && <div>Error: {error.message}</div>}
+        </>
+      ) : (
+        <div>LLM plugin not enabled.</div>
+      )}
+    </div>
+  );
+}

--- a/src/gpt-panel/panel.tsx
+++ b/src/gpt-panel/panel.tsx
@@ -3,7 +3,6 @@ import { PanelProps } from '@grafana/data';
 import { llms } from '@grafana/experimental';
 import { Button, Input, Spinner } from '@grafana/ui';
 import { useAsync } from 'react-use';
-import { getDashboardSrv, getBackendSrv } from '@grafana/runtime';
 
 interface Props extends PanelProps<{}> {}
 
@@ -22,14 +21,15 @@ export function GptPanel({ data }: Props) {
       return { enabled };
     }
 
-    let context = '';
-    try {
-      const dashboard = getDashboardSrv().getCurrent();
-      const dashJson = await getBackendSrv().get(`/api/dashboards/uid/${dashboard?.uid}`);
-      context = JSON.stringify(dashJson.dashboard.panels?.slice(0, 3));
-    } catch (err) {
-      console.error('failed getting dashboard context', err);
-    }
+    const context = JSON.stringify(
+      data.series?.map((series) => {
+        const values = series.fields[0].values.toArray();
+        return {
+          name: series.name ?? series.fields[0].name,
+          lastValues: values.slice(-5),
+        };
+      }) ?? []
+    );
 
     const response = await llms.openai.chatCompletions({
       model: 'gpt-3.5-turbo',
@@ -40,7 +40,7 @@ export function GptPanel({ data }: Props) {
     });
     setReply(response.choices[0].message.content);
     return { enabled };
-  }, [message]);
+  }, [message, data]);
 
   return (
     <div style={{ padding: '8px' }}>

--- a/src/gpt-panel/plugin.json
+++ b/src/gpt-panel/plugin.json
@@ -3,6 +3,7 @@
   "type": "panel",
   "name": "GPT Query Panel",
   "id": "grafana-gpt-query-panel",
+  "module": "./module",
   "info": {
     "keywords": ["panel"],
     "description": "Ask GPT questions and show answers inline",

--- a/src/gpt-panel/plugin.json
+++ b/src/gpt-panel/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "type": "panel",
+  "name": "GPT Query Panel",
+  "id": "grafana-gpt-query-panel",
+  "info": {
+    "keywords": ["panel"],
+    "description": "Ask GPT questions and show answers inline",
+    "author": { "name": "Grafana" },
+    "logos": {
+      "small": "img/logo.svg",
+      "large": "img/logo.svg"
+    },
+    "screenshots": [],
+    "version": "%VERSION%",
+    "updated": "%TODAY%"
+  },
+  "dependencies": {
+    "grafanaDependency": ">=9.5.2",
+    "plugins": []
+  }
+}

--- a/src/module.js
+++ b/src/module.js
@@ -1,0 +1,14 @@
+import { AppPlugin } from '@grafana/data';
+import { App } from './components/App';
+import { AppConfig } from './components/AppConfig';
+import { panelExplainer } from './extensions';
+
+export const plugin = new AppPlugin()
+  .setRootPage(App)
+  .addConfigPage({
+    title: 'Configuration',
+    icon: 'cog',
+    body: AppConfig,
+    id: 'configuration',
+  })
+  .configureExtensionLink(panelExplainer);

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,6 +3,7 @@
   "type": "app",
   "name": "LLM Examples",
   "id": "grafana-llmexamples-app",
+  "module": "./module",
   "backend": true,
   "streaming": true,
   "executable": "gpx_llmexamples",


### PR DESCRIPTION
## Summary
- add a new GPT Query Panel plugin for asking questions to GPT with dashboard context
- update README to mention the new panel example

## Testing
- `npm run lint` *(fails: Invalid option `--ignore-path`)*
- `npm run typecheck` *(fails: cannot find modules and JSX flag errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6a7eb9d883288777885521d9b884